### PR TITLE
Fix GitHub workflow kubebuilder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           os=$(go env GOOS)
           arch=$(go env GOARCH)
           version=2.3.1
-          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_${os}_${arch}.tar.gz
+          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_${os}_${arch}.tar.gz | tar -xz -C /tmp/
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
       - run: make test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,8 @@ jobs:
         run: |
           os=$(go env GOOS)
           arch=$(go env GOARCH)
-          curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+          version=2.3.1
+          curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_${os}_${arch}.tar.gz
           sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
       - run: make test
 


### PR DESCRIPTION
Fixes the broken github build workflow.

Kubebuilder seems to have changed their url redirects for the github artifact hosting and no combination of paths and artifact names that I tried could get it to work, so I'm updating the workflow to just point directly to the github artifacts. 

Note that starting with the 3.0.0 release the artifacts aren't tar/gzipped anymore so this will need to drop the tar/gz extract.