### PR TITLE
fix: use controller image for var substitution

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -23,4 +23,4 @@ vars:
     version: v1
     name: controller-manager
   fieldref:
-    fieldpath: spec.template.spec.containers[1].image
+    fieldpath: spec.template.spec.containers[0].image


### PR DESCRIPTION
Using the 2nd container's image caused the `WAITER_IMAGE` env to be set
to `kube-rbac-proxy` (if used) rather than the migrations operator image.
This change works whether or not the RBAC proxy is in use.