### PR TITLE
Fix install and add instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A Kubernetes operator to manage database migrations or similar application setup
 ## Quick Start
 
 ### Install
-
-TODO
+1. Go must be installed before installing.
+2. Install [cert-manager](https://cert-manager.io/docs/installation/)
+3. make deploy
 
 ### Usage
 
@@ -43,7 +44,7 @@ with these fields:
 - args: optional string array to be used as the upgrade Job's `args`.
 - image: optional image to use for the upgrade Job.
 - container: optional name of a container from the selected template Pod. The selected container will be used to run the upgrader.
-- labels: optional map of labels to set on the Job's pod template, 
+- labels: optional map of labels to set on the Job's pod template,
 - annotations: optional map of annotations to set on the Job's pod template,
 
 The migrator Job will contain only the single template container, initContainers will be included but sidecars will not. Any livenessProbes and readinessProbes in the template will be ignored.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: ghcr.io/coderanger/migrations-operator:latest
+        image: ghcr.io/coderanger/migrations-operator:main
         name: manager
         env:
         - name: API_HOSTNAME


### PR DESCRIPTION
The makefile was failing because `go get` is deprecated.

Once deploy the `ghcr.io/coderanger/migrations-operator:latest` image was causing trouble as seen in #5 
